### PR TITLE
Center CTA logo and tighten service list bullets

### DIFF
--- a/style.css
+++ b/style.css
@@ -567,10 +567,11 @@ input:checked + .slider:before {
 }
 .service-content ul {
   list-style: disc;
-  margin-left: 1rem;
+  list-style-position: inside;
+  margin-left: 0;
+  padding-left: 0;
   color: var(--color-brown);
   line-height: 1.6;
-  padding-left: 0;
 }
 .service-content ul li {
   margin-bottom: 0.4rem;
@@ -768,10 +769,14 @@ input:checked + .slider:before {
   max-width: 1200px;
   margin: 0 auto;
 }
+.cta-logo {
+  display: -webkit-box; display: -ms-flexbox; display: flex;
+  align-items: center;
+  justify-content: center;
+}
 .cta-logo img {
   width: 200px;
   height: auto;
-  margin-bottom: 1rem;
 }
 
 /* Tagline below the CTA logo */


### PR DESCRIPTION
## Summary
- Align CTA logo with tagline by centering the logo image.
- Reduce service bullet indent so text sits close to bullet points.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688db390cae48322a8cc64f0aa79bcad