### PR TITLE
Center services container and CTA logo

### DIFF
--- a/style.css
+++ b/style.css
@@ -531,6 +531,7 @@ input:checked + .slider:before {
   gap: 2rem;
   max-width: 1200px;
   margin: 0 auto;
+  align-items: center;
 }
 /* Stack all service items vertically by default so they appear one below another.
    This prevents them from forming a two‑column layout and instead aligns each
@@ -777,6 +778,8 @@ input:checked + .slider:before {
 .cta-logo img {
   width: 200px;
   height: auto;
+  display: block;
+  margin: 0 auto;
 }
 
 /* Tagline below the CTA logo */


### PR DESCRIPTION
## Summary
- Center the services section by aligning its flex items.
- Center the CTA logo image by converting it to a block element and auto margins.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688db6c3544083228f588f6bdc090a7b